### PR TITLE
Create a semicolon comment form, for Lisp/Clojure

### DIFF
--- a/client/export.tsx
+++ b/client/export.tsx
@@ -20,7 +20,7 @@ import { useObserver } from "mobx-react";
 import * as React from "react";
 
 export interface IExportConfig {
-  wrapper?: "star" | "star-filled" | "hash" | "slash" | "dash" | "apostrophe";
+  wrapper?: "star" | "star-filled" | "hash" | "slash" | "dash" | "apostrophe" | "semicolon";
   indent?: number;
   characters?: "basic" | "extended";
 }
@@ -95,6 +95,9 @@ export function ExportDialog({
                 </MenuItem>
                 <MenuItem value={"apostrophe"}>
                   Apostrophies <CommentTypeChip label="'" />
+                </MenuItem>
+                <MenuItem value={"semicolon"}>
+                  Apostrophies <CommentTypeChip label=";" />
                 </MenuItem>
               </Select>
             </FormControl>
@@ -203,6 +206,9 @@ function applyConfig(text: string, exportConfig: IExportConfig) {
     }
     if (exportConfig.wrapper === "apostrophe") {
       setLines(lines().map((line) => `' ${line}`));
+    }
+    if (exportConfig.wrapper === "semicolon") {
+      setLines(lines().map((line) => `; ${line}`));
     }
   }
   return text;


### PR DESCRIPTION
In many Lisps (Common Lisp, Scheme, Clojure) comments are prefixed with semicolons.

It's a quick fix to switch from apostrophe to semicolon, but it would be nice to have the option to export with semicolons directly. :)