### PR TITLE
Add Markdown export modes

### DIFF
--- a/client/export.tsx
+++ b/client/export.tsx
@@ -222,6 +222,7 @@ function applyConfig(text: string, exportConfig: IExportConfig) {
     }
     if (exportConfig.wrapper === "four-spaces") {
       setLines(lines().map((line) => `    ${line}`));
+    }
     if (exportConfig.wrapper === "semicolon") {
       setLines(lines().map((line) => `; ${line}`));
     }

--- a/client/export.tsx
+++ b/client/export.tsx
@@ -101,6 +101,7 @@ export function ExportDialog({
                 </MenuItem>
                 <MenuItem value={"four-spaces"}>
                   Four Spaces <CommentTypeChip label="    " />
+                </MenuItem>
                 <MenuItem value={"semicolon"}>
                   Apostrophies <CommentTypeChip label=";" />
                 </MenuItem>

--- a/client/export.tsx
+++ b/client/export.tsx
@@ -20,7 +20,7 @@ import { useObserver } from "mobx-react";
 import * as React from "react";
 
 export interface IExportConfig {
-  wrapper?: "star" | "star-filled" | "hash" | "slash" | "dash" | "apostrophe";
+  wrapper?: "star" | "star-filled" | "hash" | "slash" | "dash" | "apostrophe" | "backticks" | "four-spaces";
   indent?: number;
   characters?: "basic" | "extended";
 }
@@ -95,6 +95,12 @@ export function ExportDialog({
                 </MenuItem>
                 <MenuItem value={"apostrophe"}>
                   Apostrophies <CommentTypeChip label="'" />
+                </MenuItem>
+                <MenuItem value={"backticks"}>
+                  Backticks multi-line <CommentTypeChip label="``` ```" />
+                </MenuItem>
+                <MenuItem value={"four-spaces"}>
+                  Four Spaces <CommentTypeChip label="    " />
                 </MenuItem>
               </Select>
             </FormControl>
@@ -203,6 +209,16 @@ function applyConfig(text: string, exportConfig: IExportConfig) {
     }
     if (exportConfig.wrapper === "apostrophe") {
       setLines(lines().map((line) => `' ${line}`));
+    }
+    if (exportConfig.wrapper === "backticks") {
+      setLines([
+        "```",
+        ...lines(),
+        "```",
+      ]);
+    }
+    if (exportConfig.wrapper === "four-spaces") {
+      setLines(lines().map((line) => `    ${line}`));
     }
   }
   return text;


### PR DESCRIPTION
This PR adds the two code block modes for Markdown, the backticked one and the four spaces prefixed lines.