### PR TITLE
Add Rust export mode

### DIFF
--- a/client/export.tsx
+++ b/client/export.tsx
@@ -20,7 +20,7 @@ import { useObserver } from "mobx-react";
 import * as React from "react";
 
 export interface IExportConfig {
-  wrapper?: "star" | "star-filled" | "hash" | "slash" | "dash" | "apostrophe" | "semicolon" | "backticks" | "four-spaces";
+  wrapper?: "star" | "star-filled" | "hash" | "slash" | "three-slashes" | "dash" | "apostrophe" | "semicolon" | "backticks" | "four-spaces";
   indent?: number;
   characters?: "basic" | "extended";
 }
@@ -89,6 +89,9 @@ export function ExportDialog({
                 </MenuItem>
                 <MenuItem value={"slash"}>
                   Slashes <CommentTypeChip label="//" />
+                </MenuItem>
+                <MenuItem value={"three-slashes"}>
+                  Three Slashes <CommentTypeChip label="///" />
                 </MenuItem>
                 <MenuItem value={"dash"}>
                   Dashes <CommentTypeChip label="--" />
@@ -206,6 +209,9 @@ function applyConfig(text: string, exportConfig: IExportConfig) {
     }
     if (exportConfig.wrapper === "slash") {
       setLines(lines().map((line) => `// ${line}`));
+    }
+    if (exportConfig.wrapper === "three-slashes") {
+      setLines(lines().map((line) => `/// ${line}`));
     }
     if (exportConfig.wrapper === "dash") {
       setLines(lines().map((line) => `-- ${line}`));


### PR DESCRIPTION
Today i came across asciiflow, really awesome, thanks :)

While i exported my first drawing i noticed that a three slashes option is missing.
[Rust](https://doc.rust-lang.org/rust-by-example/meta/doc.html) and [c#](https://docs.microsoft.com/en-us/previous-versions/microsoft-robotics/cc998489(v=msdn.10)?redirectedfrom=MSDN) and maybe others use three slashes to mark a comment as a documentation comment.

Would be nice to have such an option.

I did not test this commit but i seems fairly simple and i made the same changes as https://github.com/lewish/asciiflow/commit/c035a8ad456ab1080100f578294449ab1551eac1.