### PR TITLE
Allow access from external machines

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = (env, argv) => ({
     warnings: true,
   },
   devServer: {
-    host: 0.0.0.0,
+    host: '0.0.0.0',
     port: 9110,
     open: false,
     // Triggers a rebuild when requesting the output filename.

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -17,6 +17,7 @@ module.exports = (env, argv) => ({
   devServer: {
     host: '0.0.0.0',
     port: 9110,
+    disableHostCheck: true,
     open: false,
     // Triggers a rebuild when requesting the output filename.
     filename: new RegExp(`.*\\/${path.basename(argv.output)}`),

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -15,6 +15,7 @@ module.exports = (env, argv) => ({
     warnings: true,
   },
   devServer: {
+    host: 0.0.0.0,
     port: 9110,
     open: false,
     // Triggers a rebuild when requesting the output filename.


### PR DESCRIPTION
I wanted to create an image of this application to use in with Docker. Due to node listening on 127.0.0.1; you cannot access the web UI from external machines.

I've added two lines to `webpack.config.js` that allow external machines to access the UI running on port 9110. These lines configure node to listen on `0.0.0.0` instead of `127.0.0.1` and disables host checking (for use behind reverse proxy).

This may be better as an option/argument/flag that can be used with `bazel run client:devserver` so that it's not the default setting, but I don't know if that's possible. Something like `--production` that would set these values so the app listens on `0.0.0.0`.

This is my first PR, so please respond with any feedback/comments/recommendations.