### PR TITLE
Updated shortcut controls based on https://github.com/lewish/asciiflow/pull/212

### DIFF
--- a/client/controller.ts
+++ b/client/controller.ts
@@ -1,5 +1,5 @@
 import * as constants from "asciiflow/client/constants";
-import { store, IModifierKeys } from "asciiflow/client/store";
+import { store, IModifierKeys, ToolMode } from "asciiflow/client/store";
 import { Vector } from "asciiflow/client/vector";
 import { screenToCell } from "asciiflow/client/view";
 import { HTMLAttributes } from "react";
@@ -65,6 +65,21 @@ export class Controller {
     // Override some special characters so that they can be handled in one place.
     let specialKeyCode = null;
 
+    if (event.altKey) {
+      if (event.key === '1') {
+        store.setToolMode(ToolMode.BOX)
+      } else if (event.key === '2') {
+        store.setToolMode(ToolMode.SELECT)
+      } else if (event.key === '3') {
+        store.setToolMode(ToolMode.FREEFORM)
+      } else if (event.key === '4') {
+        store.setToolMode(ToolMode.ARROWS)
+      } else if (event.key === '5') {
+        store.setToolMode(ToolMode.LINES)
+      } else if (event.key === '6') {
+        store.setToolMode(ToolMode.TEXT)
+      }
+    }
     if (event.ctrlKey || event.metaKey) {
       if (event.keyCode === 67) {
         specialKeyCode = constants.KEY_COPY;

--- a/client/controller.ts
+++ b/client/controller.ts
@@ -65,18 +65,25 @@ export class Controller {
     let specialKeyCode = null;
 
     if (event.altKey) {
-      if (event.key === '1') {
-        store.setToolMode(ToolMode.BOX)
-      } else if (event.key === '2') {
-        store.setToolMode(ToolMode.SELECT)
-      } else if (event.key === '3') {
-        store.setToolMode(ToolMode.FREEFORM)
-      } else if (event.key === '4') {
-        store.setToolMode(ToolMode.ARROWS)
-      } else if (event.key === '5') {
-        store.setToolMode(ToolMode.LINES)
-      } else if (event.key === '6') {
-        store.setToolMode(ToolMode.TEXT)
+      store.altPressed = true;
+      if (event.key === "1") {
+        store.setToolMode(ToolMode.BOX);
+        event.preventDefault();
+      } else if (event.key === "2") {
+        store.setToolMode(ToolMode.SELECT);
+        event.preventDefault();
+      } else if (event.key === "3") {
+        store.setToolMode(ToolMode.FREEFORM);
+        event.preventDefault();
+      } else if (event.key === "4") {
+        store.setToolMode(ToolMode.ARROWS);
+        event.preventDefault();
+      } else if (event.key === "5") {
+        store.setToolMode(ToolMode.LINES);
+        event.preventDefault();
+      } else if (event.key === "6") {
+        store.setToolMode(ToolMode.TEXT);
+        event.preventDefault();
       }
     }
     if (event.ctrlKey || event.metaKey) {
@@ -132,6 +139,9 @@ export class Controller {
   handleKeyUp(event: KeyboardEvent) {
     if (event.keyCode === 32) {
       store.panning = false;
+    }
+    if (!event.altKey) {
+      store.altPressed = false;
     }
   }
 

--- a/client/drawer.tsx
+++ b/client/drawer.tsx
@@ -396,7 +396,8 @@ export function Drawer() {
                     redo.
                   </>
                 )}{" "}
-                You can return to the previous version of ASCIIFlow{" "}
+                View shortcuts by pressing <ShortcutChip label={"alt"} />. You
+                can return to the previous version of ASCIIFlow{" "}
                 <a href="legacy">here</a>.
               </div>
             )}

--- a/client/drawer.tsx
+++ b/client/drawer.tsx
@@ -237,19 +237,20 @@ export function Drawer() {
                     name="Boxes"
                     tool={ToolMode.BOX}
                     icon={<Icons.CheckBoxOutlineBlank />}
-                    shortcut={<ShortcutChip label={'alt + 1'} />}
-                  />
+                  >
+                    <ShortcutChip label={"alt + 1"} hideUntilAlt={true} />
+                  </ToolControl>
                   <ToolControl
                     name="Select & Move"
                     tool={ToolMode.SELECT}
                     icon={<Icons.NearMe />}
-                    shortcut={<ShortcutChip label={'alt + 2'} />}
-                  />
+                  >
+                    <ShortcutChip label={"alt + 2"} hideUntilAlt={true} />
+                  </ToolControl>
                   <ToolControl
                     name="Freeform"
                     tool={ToolMode.FREEFORM}
                     icon={<Icons.Gesture />}
-                    shortcut={<ShortcutChip label={'alt + 3'} />}
                   >
                     <ListItemSecondaryAction>
                       <Chip
@@ -261,27 +262,31 @@ export function Drawer() {
                           </span>
                         }
                       />
+                      <ShortcutChip label={"alt + 3"} hideUntilAlt={true} />
                     </ListItemSecondaryAction>
                   </ToolControl>
                   <ToolControl
                     name="Arrow"
                     tool={ToolMode.ARROWS}
                     icon={<Icons.TrendingUp />}
-                    shortcut={<ShortcutChip label={'alt + 4'} />}
-                  />
+                  >
+                    <ShortcutChip label={"alt + 4"} hideUntilAlt={true} />
+                  </ToolControl>
 
                   <ToolControl
                     name="Line"
                     tool={ToolMode.LINES}
                     icon={<Icons.ShowChart />}
-                    shortcut={<ShortcutChip label={'alt + 5'} />}
-                  />
+                  >
+                    <ShortcutChip label={"alt + 5"} hideUntilAlt={true} />
+                  </ToolControl>
                   <ToolControl
                     name="Text"
                     tool={ToolMode.TEXT}
                     icon={<Icons.TextFields />}
-                    shortcut={<ShortcutChip label={'alt + 6'} />}
-                  />
+                  >
+                    <ShortcutChip label={"alt + 6"} hideUntilAlt={true} />
+                  </ToolControl>
                 </>
               )}
               <ListItem>
@@ -409,16 +414,25 @@ function ctrlOrCmd() {
   return "ctrl";
 }
 
-function ShortcutChip({ label }: { label: string }) {
-  return (
-    <Chip
-      icon={<Icons.KeyboardOutlined />}
-      label={
-        <span style={{ fontFamily: "monospace", fontSize: 12 }}>{label}</span>
-      }
-      size="small"
-    />
-  );
+function ShortcutChip({
+  label,
+  hideUntilAlt,
+}: {
+  label: string;
+  hideUntilAlt?: boolean;
+}) {
+  return useObserver(() => {
+    if (hideUntilAlt && !store.altPressed) return null;
+    return (
+      <Chip
+        icon={<Icons.KeyboardOutlined />}
+        label={
+          <span style={{ fontFamily: "monospace", fontSize: 12 }}>{label}</span>
+        }
+        size="small"
+      />
+    );
+  });
 }
 
 function ToolControl(
@@ -426,7 +440,6 @@ function ToolControl(
     tool: ToolMode;
     name: React.ReactNode;
     icon: React.ReactNode;
-    shortcut: React.ReactNode;
   }>
 ) {
   return useObserver(() => {
@@ -437,7 +450,7 @@ function ToolControl(
         onClick={() => store.setToolMode(props.tool)}
       >
         <ListItemIcon>{props.icon}</ListItemIcon>
-        <ListItemText primary={props.name} secondary={props.shortcut} />
+        <ListItemText primary={props.name} />
         {props.children}
       </ListItem>
     );

--- a/client/drawer.tsx
+++ b/client/drawer.tsx
@@ -237,16 +237,19 @@ export function Drawer() {
                     name="Boxes"
                     tool={ToolMode.BOX}
                     icon={<Icons.CheckBoxOutlineBlank />}
+                    shortcut="ALT-1"
                   />
                   <ToolControl
                     name="Select & Move"
                     tool={ToolMode.SELECT}
                     icon={<Icons.NearMe />}
+                    shortcut="ALT-2"
                   />
                   <ToolControl
                     name="Freeform"
                     tool={ToolMode.FREEFORM}
                     icon={<Icons.Gesture />}
+                    shortcut="ALT-3"
                   >
                     <ListItemSecondaryAction>
                       <Chip
@@ -264,17 +267,20 @@ export function Drawer() {
                     name="Arrow"
                     tool={ToolMode.ARROWS}
                     icon={<Icons.TrendingUp />}
+                    shortcut="ALT-4"
                   />
 
                   <ToolControl
                     name="Line"
                     tool={ToolMode.LINES}
                     icon={<Icons.ShowChart />}
+                    shortcut="ALT-5"
                   />
                   <ToolControl
                     name="Text"
                     tool={ToolMode.TEXT}
                     icon={<Icons.TextFields />}
+                    shortcut="ALT-6"
                   />
                 </>
               )}
@@ -420,6 +426,7 @@ function ToolControl(
     tool: ToolMode;
     name: React.ReactNode;
     icon: React.ReactNode;
+    shortcut: React.ReactNode;
   }>
 ) {
   return useObserver(() => {
@@ -430,7 +437,7 @@ function ToolControl(
         onClick={() => store.setToolMode(props.tool)}
       >
         <ListItemIcon>{props.icon}</ListItemIcon>
-        <ListItemText primary={props.name} />
+        <ListItemText primary={props.name} secondary={props.shortcut} />
         {props.children}
       </ListItem>
     );

--- a/client/drawer.tsx
+++ b/client/drawer.tsx
@@ -237,19 +237,19 @@ export function Drawer() {
                     name="Boxes"
                     tool={ToolMode.BOX}
                     icon={<Icons.CheckBoxOutlineBlank />}
-                    shortcut="ALT-1"
+                    shortcut={<ShortcutChip label={'alt + 1'} />}
                   />
                   <ToolControl
                     name="Select & Move"
                     tool={ToolMode.SELECT}
                     icon={<Icons.NearMe />}
-                    shortcut="ALT-2"
+                    shortcut={<ShortcutChip label={'alt + 2'} />}
                   />
                   <ToolControl
                     name="Freeform"
                     tool={ToolMode.FREEFORM}
                     icon={<Icons.Gesture />}
-                    shortcut="ALT-3"
+                    shortcut={<ShortcutChip label={'alt + 3'} />}
                   >
                     <ListItemSecondaryAction>
                       <Chip
@@ -267,20 +267,20 @@ export function Drawer() {
                     name="Arrow"
                     tool={ToolMode.ARROWS}
                     icon={<Icons.TrendingUp />}
-                    shortcut="ALT-4"
+                    shortcut={<ShortcutChip label={'alt + 4'} />}
                   />
 
                   <ToolControl
                     name="Line"
                     tool={ToolMode.LINES}
                     icon={<Icons.ShowChart />}
-                    shortcut="ALT-5"
+                    shortcut={<ShortcutChip label={'alt + 5'} />}
                   />
                   <ToolControl
                     name="Text"
                     tool={ToolMode.TEXT}
                     icon={<Icons.TextFields />}
-                    shortcut="ALT-6"
+                    shortcut={<ShortcutChip label={'alt + 6'} />}
                   />
                 </>
               )}

--- a/client/store/index.ts
+++ b/client/store/index.ts
@@ -151,6 +151,8 @@ export class Store {
 
   @observable public panning = false;
 
+  @observable public altPressed = false;
+
   @observable public currentCursor: string = "default";
 
   public readonly darkMode = Persistent.json(


### PR DESCRIPTION
Branched from https://github.com/lewish/asciiflow/pull/212

- Changes rendering / layout
- Hides shortcut buttons until alt is pressed
- Adds help text for shortcuts
- Prevents default alt + number behaviour on chrome that switches tabs