### PR TITLE
Fix overflown instructions in drawer (#250)

### DIFF
--- a/client/drawer.scss
+++ b/client/drawer.scss
@@ -5,6 +5,8 @@
   max-width: 380px;
   z-index: 11;
   border-radius: 8px !important;
+  max-height: calc(100vh - 20px);
+  overflow: auto;
 
   .logo {
     height: 30px;


### PR DESCRIPTION
On lower DPI displays (or when zoomed in on the page) the drawer was sticking out of visible area and was inaccessible. These CSS rules fix it.