### PR TITLE
Bump GH actions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,14 +14,14 @@ jobs:
     steps:
       # Checks out a copy of your repository.
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Builds code using bazelisk and copies the site folder out of the bazel symlinked dir.
       - name: Build the site
         uses: "docker://mattinsler/bazelisk:latest"
         with:
           args: bash -c "bazel build site/... && cp -r --dereference bazel-bin/site ./deploy"
-  
+
       # Deploy the site to Cloudflare.
       - name: Publish
         uses: cloudflare/pages-action@1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       # Checks out a copy of your repository.
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Builds code and runs the tests using Bazelisk.
       - name: Run tests


### PR DESCRIPTION
Old ones based on Node 16 are deprecated.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20