### PR TITLE
Call `preventDefault()` on Cmd+Z/Cmd+Shift+Z/Cmd+Y

### DIFF
--- a/client/controller.ts
+++ b/client/controller.ts
@@ -103,9 +103,13 @@ export class Controller {
         } else {
           store.currentCanvas.undo();
         }
+        // Disable browser-specific behavior on Cmd/Ctrl+Z: https://github.com/lewish/asciiflow/issues/189
+        event.preventDefault();
       }
       if (event.keyCode === 89) {
         store.currentCanvas.redo();
+        // Disable browser-specific behavior on Cmd/Ctrl+Y: https://github.com/lewish/asciiflow/issues/189
+        event.preventDefault();
       }
       if (event.keyCode === 88) {
         specialKeyCode = constants.KEY_CUT;


### PR DESCRIPTION
This PR calls `preventDefault()` for:
- Cmd/Ctrl+Z
- Cmd/Ctrl+Shift+Z
- Cmd/Ctrl+Y

This partially addresses https://github.com/lewish/asciiflow/issues/189. I have a feeling we’ll be safe just calling `event.preventDefault()` on _any_ keyboard event, but I don’t feel like testing it :D